### PR TITLE
Allow scheduling of CLI actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,15 @@ $ cloudkeeper --collector aws --cleanup --register-cli-action "cleanup_begin:mat
 As a side note, there is a plugin [plugins/cleanup_volumes/](plugins/cleanup_volumes/) that does just that. It was written before cloudkeeper had its own CLI.
 
 
+## Warning
+Cloudkeeper is designed to clean up resources. As such act with caution when selecting and filtering resources for cleanup. **The default input to any CLI command is the list of all cloud resources.** Meaning when you run `match resource_type = aws_ec2_volume` it runs this match against all resources.
+This however also means if you run `delete --yes` without any `match` or other filter before it, cloudkeeper sequentially runs the delete against all cloud resources.  
+**It is the equivalent of `rm -rf /` for your cloud.**  
+An even more efficient destructive command is `clean; cleanup`. In this case cloudkeeper would first mark all resources for cleaning, create a cleanup plan and then delete them in a very efficient and parallelized manner.
+
+When doing a resource cleanup selection for the first time it is good practice to confirm the list of selected resources for plausibility using something like `match clean = true | count` or `match clean = true | count resource_type` before issuing the `cleanup` command.
+
+
 ## Data Structure
 ![Cloudkeeper Graph](https://raw.githubusercontent.com/mesosphere/cloudkeeper/master/misc/cloudkeeper_graph.png "Cloudkeeper Graph")
 Internally Cloudkeeper stores all resources inside a non-cyclic directed graph. Each node (resource) that is added to the graph must inherit [BaseResource](cloudkeeper/cloudkeeper/baseresources.py). Dependencies within the graph are used to determine the order of resource cleanup. Meaning a resource likely can not be deleted if it has children (successors).

--- a/cloudkeeper/cloudkeeper/__main__.py
+++ b/cloudkeeper/cloudkeeper/__main__.py
@@ -103,7 +103,7 @@ def main() -> None:
     dispatch_event(Event(EventType.STARTUP))
 
     # We wait for the shutdown Event to be set() and then end the program
-    # While doing so we print the list of active threads once per minute
+    # While doing so we print the list of active threads once per 15 minutes
     while not shutdown_event.is_set():
         log_stats()
         shutdown_event.wait(900)

--- a/cloudkeeper/cloudkeeper/__main__.py
+++ b/cloudkeeper/cloudkeeper/__main__.py
@@ -8,6 +8,7 @@ from cloudkeeper.graph import GraphContainer
 from cloudkeeper.pluginloader import PluginLoader
 from cloudkeeper.baseplugin import PluginType
 from cloudkeeper.web import WebServer
+from cloudkeeper.scheduler import Scheduler
 from cloudkeeper.args import get_arg_parser, ArgumentParser
 from cloudkeeper.processor import Processor
 from cloudkeeper.cleaner import Cleaner
@@ -39,6 +40,7 @@ def main() -> None:
 
     Cli.add_args(arg_parser)
     WebServer.add_args(arg_parser)
+    Scheduler.add_args(arg_parser)
     Processor.add_args(arg_parser)
     Cleaner.add_args(arg_parser)
     PluginLoader.add_args(arg_parser)
@@ -75,8 +77,13 @@ def main() -> None:
     graph_collector = GraphCollector(graph_container)
     REGISTRY.register(graph_collector)
 
+    # Scheduler() starts an APScheduler instance
+    scheduler = Scheduler(graph_container)
+    scheduler.daemon = True
+    scheduler.start()
+
     # Cli() is the CLI Thread
-    cli = Cli(graph_container)
+    cli = Cli(graph_container, scheduler)
     cli.daemon = True
     cli.start()
 

--- a/cloudkeeper/cloudkeeper/baseresources.py
+++ b/cloudkeeper/cloudkeeper/baseresources.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone, timedelta
 from hashlib import sha256
 import logging
 import uuid
+import networkx.algorithms.dag
 from typing import Dict, Iterator, List, Tuple
 from cloudkeeper.utils import make_valid_timestamp
 from prometheus_client import Counter, Summary
@@ -307,6 +308,16 @@ class BaseResource(ABC):
         """Returns an iterator of the node's child nodes
         """
         return graph.successors(self)
+
+    def ancestors(self, graph) -> Iterator:
+        """Returns an iterator of the node's ancestors
+        """
+        return networkx.algorithms.dag.ancestors(graph, self)
+
+    def descendants(self, graph) -> Iterator:
+        """Returns an iterator of the node's descendants
+        """
+        return networkx.algorithms.dag.descendants(graph, self)
 
     def __getstate__(self):
         ret = self.__dict__.copy()

--- a/cloudkeeper/cloudkeeper/cli.py
+++ b/cloudkeeper/cloudkeeper/cli.py
@@ -2,6 +2,7 @@ import threading
 import logging
 import inspect
 import re
+import time
 from typing import Iterable, Tuple, Any
 from collections import deque
 from itertools import islice
@@ -544,6 +545,28 @@ class CliHandler:
         for item in items:
             item_attr = self.get_item_attr(item, attr)
             if (not negate_match and item_attr is not None) or (negate_match and item_attr is None):
+                yield item
+
+    def cmd_sleep(self, items: Iterable, args: str) -> Iterable:
+        '''Usage: | sleep [pipe] <seconds>
+
+        Sleep for the specified number of seconds.
+        If pipe is specified sleep will pipe through all input items.
+        '''
+        pipe = False
+        if args.startswith('pipe '):
+            pipe = True
+            args = args[5:]
+
+        seconds = args
+        if len(seconds) == 0 or bool(re.search('[^0-9.]', str(seconds))):
+            raise ValueError('invalid number of seconds')
+
+        seconds = float(seconds)
+        time.sleep(seconds)
+
+        if pipe:
+            for item in items:
                 yield item
 
     def get_item_attr(self, item: BaseResource, attr: str) -> Any:

--- a/cloudkeeper/cloudkeeper/cli.py
+++ b/cloudkeeper/cloudkeeper/cli.py
@@ -358,6 +358,8 @@ class CliHandler:
         '''Usage: | predecessors
 
         List a resource's predecessors in the graph.
+
+        Predecessors are a resource's parents.
         '''
         return self.relatives(items, 'predecessors')
 
@@ -365,6 +367,8 @@ class CliHandler:
         '''Usage: | successors
 
         List a resource's successors in the graph.
+
+        Successors are a resource's children.
         '''
         return self.relatives(items, 'successors')
 
@@ -372,6 +376,9 @@ class CliHandler:
         '''Usage: | ancestors
 
         List a resource's ancestors in the graph.
+
+        Ancestors are a resource's parents and their parents
+        and their parents and so on.
         '''
         return self.relatives(items, 'ancestors')
 
@@ -379,6 +386,9 @@ class CliHandler:
         '''Usage: | descendants
 
         List a resource's descendants in the graph.
+
+        Descendants are a resource's children and their children
+        and their children and so on.
         '''
         return self.relatives(items, 'descendants')
 

--- a/cloudkeeper/cloudkeeper/cli.py
+++ b/cloudkeeper/cloudkeeper/cli.py
@@ -18,7 +18,7 @@ from prompt_toolkit.shortcuts import button_dialog
 from cloudkeeper.baseresources import BaseResource
 from cloudkeeper.graph import Graph, GraphContainer, get_resource_attributes, graph2pickle
 from cloudkeeper.args import ArgumentParser
-from cloudkeeper.event import dispatch_event, Event, EventType, add_event_listener, remove_event_listener
+from cloudkeeper.event import dispatch_event, Event, EventType, add_event_listener, remove_event_listener, list_event_listeners
 from cloudkeeper.utils import parse_delta, make_valid_timestamp, split_esc
 from cloudkeeper.cleaner import Cleaner
 from pprint import pformat
@@ -628,6 +628,13 @@ and chain multipe commands using the semicolon (;).
         E.g. echo @TODAY@
         '''
         yield args
+
+    def cmd_listeners(self, items: Iterable, args: str) -> Iterable:
+        '''Usage: listeners
+
+        List all registered event listeners.
+        '''
+        yield from list_event_listeners()
 
     def cmd_jobs(self, items: Iterable, args: str) -> Iterable:
         '''Usage: jobs

--- a/cloudkeeper/cloudkeeper/cli.py
+++ b/cloudkeeper/cloudkeeper/cli.py
@@ -359,22 +359,36 @@ class CliHandler:
 
         List a resource's predecessors in the graph.
         '''
-        for item in items:
-            if not isinstance(item, BaseResource):
-                raise RuntimeError(f'Item {item} is not a valid resource - tag update failed')
-            for node in item.predecessors(self.graph):
-                yield node
+        return self.relatives(items, 'predecessors')
 
     def cmd_successors(self, items: Iterable, args: str) -> Iterable:
         '''Usage: | successors
 
         List a resource's successors in the graph.
         '''
-        for item in items:
-            if not isinstance(item, BaseResource):
-                raise RuntimeError(f'Item {item} is not a valid resource - tag update failed')
-            for node in item.successors(self.graph):
-                yield node
+        return self.relatives(items, 'successors')
+
+    def cmd_ancestors(self, items: Iterable, args: str) -> Iterable:
+        '''Usage: | ancestors
+
+        List a resource's ancestors in the graph.
+        '''
+        return self.relatives(items, 'ancestors')
+
+    def cmd_descendants(self, items: Iterable, args: str) -> Iterable:
+        '''Usage: | descendants
+
+        List a resource's descendants in the graph.
+        '''
+        return self.relatives(items, 'descendants')
+
+    def relatives(self, nodes: Iterable, group: str) -> Iterable:
+        '''Return a group of relatives for any given list of nodes
+        '''
+        for node in nodes:
+            if not isinstance(node, BaseResource):
+                raise RuntimeError(f'Node {node} is not a valid resource')
+            yield from getattr(node, group)(self.graph)
 
     def cmd_tee(self, items: Iterable, args: str) -> Iterable:
         '''Usage: | tee [-a] <filename>
@@ -409,8 +423,7 @@ class CliHandler:
                 raise ValueError(f'Item {item} has no attribute {attr}')
             return attr_value
 
-        for item in sorted(list(items), key=getsortkey, reverse=reverse):
-            yield item
+        yield from sorted(list(items), key=getsortkey, reverse=reverse)
 
     def cmd_rsort(self, items: Iterable, args: str, reverse: bool = False) -> Iterable:
         '''Usage: | rsort [attribute]

--- a/cloudkeeper/cloudkeeper/cli.py
+++ b/cloudkeeper/cloudkeeper/cli.py
@@ -655,7 +655,7 @@ and chain multipe commands using the semicolon (;).
             hour           0–23
             day of month   1–31
             month          1–12
-            day of week    0–7
+            day of week    0-6 or mon,tue,wed,thu,fri,sat,sun
 
         Example:
             Count EC2 Instances every three hours

--- a/cloudkeeper/cloudkeeper/cli.py
+++ b/cloudkeeper/cloudkeeper/cli.py
@@ -40,12 +40,16 @@ class Cli(threading.Thread):
                 log.error(f'Invalid CLI action {action}')
                 continue
             event, command = action.split(':', 1)
+            one_shot = False
             event = event.strip()
             command = command.strip()
+            if event.startswith('1'):
+                one_shot = True
+                event = event[1:]
             for e in EventType:
                 if event == e.value:
                     f = partial(self.cli_event_handler, command)
-                    add_event_listener(e, f, blocking=True)
+                    add_event_listener(e, f, blocking=True, one_shot=one_shot)
                     break
             else:
                 log.error(f'Invalid event type {event}')

--- a/cloudkeeper/cloudkeeper/cli.py
+++ b/cloudkeeper/cloudkeeper/cli.py
@@ -355,47 +355,55 @@ class CliHandler:
         return (doc,)
 
     def cmd_predecessors(self, items: Iterable, args: str) -> Iterable:
-        '''Usage: | predecessors
+        '''Usage: | predecessors [--with-origin]
 
         List a resource's predecessors in the graph.
-
         Predecessors are a resource's parents.
+
+        If --with-origin is specified the origin resource(s) will also be output.
         '''
-        return self.relatives(items, 'predecessors')
+        return self.relatives(items, 'predecessors', args)
 
     def cmd_successors(self, items: Iterable, args: str) -> Iterable:
-        '''Usage: | successors
+        '''Usage: | successors [--with-origin]
 
         List a resource's successors in the graph.
-
         Successors are a resource's children.
+
+        If --with-origin is specified the origin resource(s) will also be output.
         '''
-        return self.relatives(items, 'successors')
+        return self.relatives(items, 'successors', args)
 
     def cmd_ancestors(self, items: Iterable, args: str) -> Iterable:
-        '''Usage: | ancestors
+        '''Usage: | ancestors [--with-origin]
 
         List a resource's ancestors in the graph.
-
         Ancestors are a resource's parents and their parents
         and their parents and so on.
+
+        If --with-origin is specified the origin resource(s) will also be output.
         '''
-        return self.relatives(items, 'ancestors')
+        return self.relatives(items, 'ancestors', args)
 
     def cmd_descendants(self, items: Iterable, args: str) -> Iterable:
-        '''Usage: | descendants
+        '''Usage: | descendants [--with-origin]
 
         List a resource's descendants in the graph.
-
         Descendants are a resource's children and their children
         and their children and so on.
-        '''
-        return self.relatives(items, 'descendants')
 
-    def relatives(self, nodes: Iterable, group: str) -> Iterable:
+        If --with-origin is specified the origin resource(s) will also be output.
+        '''
+        return self.relatives(items, 'descendants', args)
+
+    def relatives(self, nodes: Iterable, group: str, args: str) -> Iterable:
         '''Return a group of relatives for any given list of nodes
         '''
+        output_origin_node = True if args == '--with-origin' else False
+
         for node in nodes:
+            if output_origin_node:
+                yield node
             if not isinstance(node, BaseResource):
                 raise RuntimeError(f'Node {node} is not a valid resource')
             yield from getattr(node, group)(self.graph)

--- a/cloudkeeper/cloudkeeper/event.py
+++ b/cloudkeeper/cloudkeeper/event.py
@@ -60,7 +60,7 @@ def dispatch_event(event: Event, blocking: bool = False) -> None:
     """Dispatch an Event
     """
     waiting_str = '' if blocking else 'not '
-    log.debug(f'Dispatching event {event.event_type} and {waiting_str}waiting for listeners to return')
+    log.debug(f'Dispatching event {event.event_type.name} and {waiting_str}waiting for listeners to return')
 
     if event.event_type not in _events.keys():
         return
@@ -111,7 +111,7 @@ def add_event_listener(event_type: EventType, listener: Callable, blocking: bool
     if timeout is None:
         timeout = ArgumentParser.args.event_timeout
 
-    log.debug(f'Registering {listener} with event {event_type} (blocking: {blocking}, one-shot: {one_shot})')
+    log.debug(f'Registering {listener} with event {event_type.name} (blocking: {blocking}, one-shot: {one_shot})')
     with _events_lock.write_access:
         if not event_listener_registered(event_type, listener):
             _events[event_type][listener] = {'blocking': blocking, 'timeout': timeout, 'one-shot': one_shot, 'lock': Lock()}
@@ -124,7 +124,7 @@ def remove_event_listener(event_type: EventType, listener: Callable) -> bool:
     """
     with _events_lock.write_access:
         if event_listener_registered(event_type, listener):
-            log.debug(f'Removing {listener} from event {event_type}')
+            log.debug(f'Removing {listener} from event {event_type.name}')
             del _events[event_type][listener]
             if len(_events[event_type]) == 0:
                 del _events[event_type]

--- a/cloudkeeper/cloudkeeper/event.py
+++ b/cloudkeeper/cloudkeeper/event.py
@@ -2,7 +2,7 @@ from cloudkeeper.utils import RWLock
 from cloudkeeper.args import ArgumentParser
 from collections import defaultdict
 from threading import Thread, Lock
-from typing import Callable
+from typing import Callable, Iterable
 from enum import Enum
 import os
 import time
@@ -130,6 +130,13 @@ def remove_event_listener(event_type: EventType, listener: Callable) -> bool:
                 del _events[event_type]
             return True
         return False
+
+
+def list_event_listeners() -> Iterable:
+    with _events_lock.read_access:
+        for event_type, listeners in _events.items():
+            for listener, listener_data in listeners.items():
+                yield f"{event_type.name}: {listener}, blocking: {listener_data['blocking']}, one-shot: {listener_data['one-shot']}"
 
 
 def add_args(arg_parser: ArgumentParser) -> None:

--- a/cloudkeeper/cloudkeeper/event.py
+++ b/cloudkeeper/cloudkeeper/event.py
@@ -81,7 +81,7 @@ def dispatch_event(event: Event, blocking: bool = False) -> None:
             thread_name = f"{event.event_type.name.lower()}_event-{getattr(listener, '__name__', 'anonymous')}"
             t = Thread(target=listener, args=[event], name=thread_name)
             if blocking or listener_data['blocking']:
-                threads[listener] = t
+                threads[t] = listener
             t.start()
         except Exception:
             log.exception('Caught unhandled event callback exception')
@@ -92,7 +92,7 @@ def dispatch_event(event: Event, blocking: bool = False) -> None:
                 listener_data['lock'].release()
 
     start_time = time.time()
-    for listener, thread in threads.items():
+    for thread, listener in threads.items():
         timeout = start_time + listeners[listener]['timeout'] - time.time()
         if timeout < 1:
             timeout = 1

--- a/cloudkeeper/cloudkeeper/event.py
+++ b/cloudkeeper/cloudkeeper/event.py
@@ -111,7 +111,7 @@ def add_event_listener(event_type: EventType, listener: Callable, blocking: bool
     if timeout is None:
         timeout = ArgumentParser.args.event_timeout
 
-    log.debug(f'Registering {listener} with event {event_type}')
+    log.debug(f'Registering {listener} with event {event_type} (blocking: {blocking}, one-shot: {one_shot})')
     with _events_lock.write_access:
         if not event_listener_registered(event_type, listener):
             _events[event_type][listener] = {'blocking': blocking, 'timeout': timeout, 'one-shot': one_shot, 'lock': Lock()}

--- a/cloudkeeper/cloudkeeper/scheduler.py
+++ b/cloudkeeper/cloudkeeper/scheduler.py
@@ -3,6 +3,9 @@ import logging
 import re
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
+from apscheduler.jobstores.base import JobLookupError
+from apscheduler.job import Job
+from typing import Iterable
 from cloudkeeper.cli import register_cli_action, cli_event_handler
 from cloudkeeper.args import ArgumentParser
 from cloudkeeper.event import Event, EventType, add_event_listener, remove_event_listener
@@ -17,7 +20,7 @@ class Scheduler(threading.Thread):
         self.exit = threading.Event()
         self.gc = gc
         self._sched = BackgroundScheduler(daemon=True)
-        self._event_prefix = tuple((e.name.lower() for e in EventType))
+        self._event_prefixes = tuple((f'{e.name.lower()}:' for e in EventType))
         add_event_listener(EventType.SHUTDOWN, self.shutdown)
 
     def __del__(self):
@@ -41,26 +44,38 @@ class Scheduler(threading.Thread):
         log.debug(f'Running scheduled command {command}')
         return cli_event_handler(command, graph=self.gc.graph)
 
-    def add_job(self, args: str) -> None:
+    def add_job(self, args: str) -> Job:
         cron = re.split(r'\s+', args, 5)
         if len(cron) != 6:
             raise ValueError(f'Invalid job {args}')
         minute, hour, day, month, day_of_week, command = cron
-        if str(command).startswith(self._event_prefix):
+        if str(command).startswith(self._event_prefixes):
             event, cmd = command.split(':', 1)
             log.debug(f'Scheduling to register command "{cmd}" for event {event} at minute={minute}, hour={hour}, day={day}, month={month}, day_of_week={day_of_week}')
-            self._sched.add_job(register_cli_action, 'cron', args=[command, True], minute=minute, hour=hour, day=day, month=month, day_of_week=day_of_week)
+            job = self._sched.add_job(register_cli_action, 'cron', args=[command, True], minute=minute, hour=hour, day=day, month=month, day_of_week=day_of_week)
         else:
             log.debug(f'Scheduling command "{command}" at minute={minute}, hour={hour}, day={day}, month={month}, day_of_week={day_of_week}')
-            self._sched.add_job(self.scheduled_command, 'cron', args=[command], minute=minute, hour=hour, day=day, month=month, day_of_week=day_of_week)
+            job = self._sched.add_job(self.scheduled_command, 'cron', args=[command], minute=minute, hour=hour, day=day, month=month, day_of_week=day_of_week)
+        return job
 
-    def get_jobs(self) -> None:
+    def remove_job(self, job_id: str) -> bool:
+        try:
+            self._sched.remove_job(job_id)
+        except JobLookupError:
+            log.error(f"Couldn't find job with id {job_id}")
+        else:
+            return True
+        return False
+
+    def get_jobs(self) -> Iterable:
         for job in self._sched.get_jobs():
             if isinstance(job.trigger, CronTrigger):
                 trigger_map = {}
                 for field in job.trigger.fields:
                     trigger_map[field.name] = str(field)
-                yield f"{trigger_map.get('minute')} {trigger_map.get('hour')} {trigger_map.get('day')} {trigger_map.get('month')} {trigger_map.get('day_of_week')} {job.args[0]}"
+                cron_line = (f"{job.id}: {trigger_map.get('minute')} {trigger_map.get('hour')} {trigger_map.get('day')}"
+                             f" {trigger_map.get('month')} {trigger_map.get('day_of_week')} {job.args[0]}")
+                yield cron_line
 
     @staticmethod
     def add_args(arg_parser: ArgumentParser) -> None:

--- a/cloudkeeper/cloudkeeper/scheduler.py
+++ b/cloudkeeper/cloudkeeper/scheduler.py
@@ -39,11 +39,14 @@ class Scheduler(threading.Thread):
 
     def read_config(self, config_file: str) -> None:
         log.debug(f'Reading scheduler configuration file {config_file}')
-        with open(config_file, 'r') as fp:
-            for line in fp:
-                line = line.strip()
-                if not line.startswith('#'):
-                    self.add_job(line)
+        try:
+            with open(config_file, 'r') as fp:
+                for line in fp:
+                    line = line.strip()
+                    if not line.startswith('#'):
+                        self.add_job(line)
+        except Exception:
+            log.exception(f'Failed to read scheduler configuration file {config_file}')
 
     def scheduled_command(self, command):
         log.debug(f'Running scheduled command {command}')

--- a/cloudkeeper/cloudkeeper/scheduler.py
+++ b/cloudkeeper/cloudkeeper/scheduler.py
@@ -1,0 +1,67 @@
+import threading
+import logging
+import re
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+from cloudkeeper.cli import register_cli_action, cli_event_handler
+from cloudkeeper.args import ArgumentParser
+from cloudkeeper.event import Event, EventType, add_event_listener, remove_event_listener
+
+log = logging.getLogger(__name__)
+
+
+class Scheduler(threading.Thread):
+    def __init__(self, gc) -> None:
+        super().__init__()
+        self.name = 'scheduler'
+        self.exit = threading.Event()
+        self.gc = gc
+        self._sched = BackgroundScheduler(daemon=True)
+        self._event_prefix = tuple((e.name.lower() for e in EventType))
+        add_event_listener(EventType.SHUTDOWN, self.shutdown)
+
+    def __del__(self):
+        remove_event_listener(EventType.SHUTDOWN, self.shutdown)
+
+    def run(self):
+        self._sched.start()
+        if ArgumentParser.args.scheduler_conf:
+            self.read_config(ArgumentParser.args.scheduler_conf)
+        self.exit.wait()
+
+    def shutdown(self, event: Event):
+        log.debug(f'Received request to shutdown scheduler {event.event_type}')
+        self._sched.shutdown()
+        self.exit.set()
+
+    def read_config(self, config_file: str) -> None:
+        pass
+
+    def scheduled_command(self, command):
+        log.debug(f'Running scheduled command {command}')
+        return cli_event_handler(command, graph=self.gc.graph)
+
+    def add_job(self, args: str) -> None:
+        cron = re.split(r'\s+', args, 5)
+        if len(cron) != 6:
+            raise ValueError(f'Invalid job {args}')
+        minute, hour, day, month, day_of_week, command = cron
+        if str(command).startswith(self._event_prefix):
+            event, cmd = command.split(':', 1)
+            log.debug(f'Scheduling to register command "{cmd}" for event {event} at minute={minute}, hour={hour}, day={day}, month={month}, day_of_week={day_of_week}')
+            self._sched.add_job(register_cli_action, 'cron', args=[command, True], minute=minute, hour=hour, day=day, month=month, day_of_week=day_of_week)
+        else:
+            log.debug(f'Scheduling command "{command}" at minute={minute}, hour={hour}, day={day}, month={month}, day_of_week={day_of_week}')
+            self._sched.add_job(self.scheduled_command, 'cron', args=[command], minute=minute, hour=hour, day=day, month=month, day_of_week=day_of_week)
+
+    def get_jobs(self) -> None:
+        for job in self._sched.get_jobs():
+            if isinstance(job.trigger, CronTrigger):
+                trigger_map = {}
+                for field in job.trigger.fields:
+                    trigger_map[field.name] = str(field)
+                yield f"{trigger_map.get('minute')} {trigger_map.get('hour')} {trigger_map.get('day')} {trigger_map.get('month')} {trigger_map.get('day_of_week')} {job.args[0]}"
+
+    @staticmethod
+    def add_args(arg_parser: ArgumentParser) -> None:
+        arg_parser.add_argument('--scheduler-conf', help='Scheduler Config', default=None, dest='scheduler_conf', type=str)

--- a/cloudkeeper/cloudkeeper/web.py
+++ b/cloudkeeper/cloudkeeper/web.py
@@ -138,7 +138,7 @@ def validate_pki(req, resp, resource, params):
         except json.decoder.JSONDecodeError:
             raise falcon.HTTPUnauthorized('Authentication required')
         else:
-            if data.get('pki') != ArgumentParser.args.web_pki:
+            if not isinstance(data, dict) or data.get('pki') != ArgumentParser.args.web_pki:
                 raise falcon.HTTPUnauthorized('Invalid PKI')
         return True
 

--- a/cloudkeeper/setup.py
+++ b/cloudkeeper/setup.py
@@ -29,6 +29,7 @@ setup(
         'defaultlist',
         'prompt_toolkit',
         'Pympler',
+        'tzlocal',
     ],
     setup_requires=['pytest-runner'],
     tests_require=['pytest'],

--- a/cloudkeeper/setup.py
+++ b/cloudkeeper/setup.py
@@ -25,6 +25,7 @@ setup(
         'falcon',
         'requests',
         'prometheus_client',
+        'apscheduler',
         'defaultlist',
         'prompt_toolkit',
         'Pympler',

--- a/plugins/remote_event_callback/README.md
+++ b/plugins/remote_event_callback/README.md
@@ -1,0 +1,2 @@
+# cloudkeeper-plugin-remote_event_callback
+Remote Event Callback Plugin for Cloudkeeper

--- a/plugins/remote_event_callback/cloudkeeper_plugin_remote_event_callback/__init__.py
+++ b/plugins/remote_event_callback/cloudkeeper_plugin_remote_event_callback/__init__.py
@@ -1,0 +1,57 @@
+import logging
+import threading
+import requests
+from functools import partial
+from cloudkeeper.baseplugin import BasePlugin
+from cloudkeeper.args import ArgumentParser
+from cloudkeeper.event import Event, EventType, add_event_listener, remove_event_listener
+
+log = logging.getLogger('cloudkeeper.' + __name__)
+
+
+class RemoteEventCallbackPlugin(BasePlugin):
+    def __init__(self):
+        super().__init__()
+        self.name = 'remote_event_callback'
+        self.exit = threading.Event()
+        add_event_listener(EventType.SHUTDOWN, self.shutdown)
+
+        for endpoint in ArgumentParser.args.remote_event_endpoint:
+            for event_type in EventType:
+                event_prefix = f'{event_type.name.lower()}:'
+                if str(endpoint).startswith(event_prefix):
+                    endpoint = endpoint[len(event_prefix):]
+                    f = partial(self.remote_event_callback, endpoint)
+                    add_event_listener(event_type, f, blocking=False, one_shot=False)
+            else:
+                log.error(f'Invalid remote event callback endpoint {endpoint}')
+
+    def __del__(self):
+        remove_event_listener(EventType.SHUTDOWN, self.shutdown)
+
+    def go(self):
+        self.exit.wait()
+
+    @staticmethod
+    def remote_event_callback(endpoint: str, event: Event):
+        log.info(f'Received event {event.event_type.name}: calling {endpoint}')
+        try:
+            if ArgumentParser.args.remote_event_callback_pki:
+                r = requests.post(endpoint, json={'pki': ArgumentParser.args.remote_event_callback_pki})
+            else:
+                r = requests.post(endpoint)
+            if r.json().get('status') == 'ok':
+                log.debug(f'Successfully called endpoint {endpoint} for event {event.event_type.name}')
+            else:
+                log.error(f'Failure when calling endpoint {endpoint} for event {event.event_type.name}')
+        except Exception:
+            log.exception(f'An unhandeled exception occured while calling endpoint {endpoint} for event {event.event_type.name}')
+
+    @staticmethod
+    def add_args(arg_parser: ArgumentParser) -> None:
+        arg_parser.add_argument('--remote-event-callback-endpoint', help='Remote Event Callback Endpoint', default=[], dest='remote_event_endpoint', type=str, nargs='+')
+        arg_parser.add_argument('--remote-event-callback-pki', help='Remote Event Callback PKI', default=None, dest='remote_event_callback_pki', type=str)
+
+    def shutdown(self, event: Event):
+        log.debug(f'Received event {event.event_type} - shutting down example plugin')
+        self.exit.set()

--- a/plugins/remote_event_callback/setup.cfg
+++ b/plugins/remote_event_callback/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/plugins/remote_event_callback/setup.py
+++ b/plugins/remote_event_callback/setup.py
@@ -1,0 +1,54 @@
+import os
+from setuptools import setup, find_packages
+
+
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+
+setup(
+    name="cloudkeeper-plugin-remote_event_callback",
+    version="0.0.2",
+    description="Cloudkeeper Remote Event Callback Plugin",
+    license="Apache 2.0",
+    packages=find_packages(),
+    long_description=read('README.md'),
+    entry_points={
+        'cloudkeeper.plugins': [
+            'remote_event_callback = cloudkeeper_plugin_remote_event_callback:RemoteEventCallbackPlugin',
+        ]
+    },
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=[
+        'cloudkeeper',
+        'requests',
+    ],
+    setup_requires=["pytest-runner"],
+    tests_require=["pytest"],
+    classifiers=[
+        # Current project status
+        'Development Status :: 4 - Beta',
+
+        # Audience
+        'Intended Audience :: System Administrators',
+        'Intended Audience :: Information Technology',
+
+        # License information
+        'License :: OSI Approved :: Apache Software License',
+
+        # Supported python versions
+        'Programming Language :: Python :: 3.8',
+
+        # Supported OS's
+        'Operating System :: POSIX :: Linux',
+        'Operating System :: Unix',
+
+        # Extra metadata
+        'Environment :: Console',
+        'Natural Language :: English',
+        'Topic :: Security',
+        'Topic :: Utilities',
+    ],
+    keywords='cloud security'
+)

--- a/plugins/remote_event_callback/test/test_args.py
+++ b/plugins/remote_event_callback/test/test_args.py
@@ -1,0 +1,10 @@
+from cloudkeeper.args import get_arg_parser, ArgumentParser
+from cloudkeeper_plugin_remote_event_callback import RemoteEventCallbackPlugin
+
+
+def test_args():
+    arg_parser = get_arg_parser()
+    RemoteEventCallbackPlugin.add_args(arg_parser)
+    arg_parser.parse_args()
+    assert len(ArgumentParser.args.remote_event_endpoint) == 0
+    assert ArgumentParser.args.remote_event_callback_pki is None

--- a/plugins/remote_event_callback/tox.ini
+++ b/plugins/remote_event_callback/tox.ini
@@ -1,0 +1,34 @@
+[tox]
+envlist = py38-{syntax,tests}
+
+[flake8]
+max-line-length=240
+exclude =
+  .git,.tox,__pycache__,.idea,.pytest_cache
+application-import-names=cloudkeeper_plugin_remote_event_callback
+ignore=F403, F405, E722, N806, N813, E266, W503
+
+[pytest]
+addopts= --cov=cloudkeeper_plugin_remote_event_callback -rs -vv
+testpaths=
+  test
+
+[testenv]
+install_command = python -m pip install -f /build {opts} {packages}
+usedevelop = true
+
+[testenv:py38-syntax]
+platform = linux
+deps =
+  flake8
+  pep8-naming
+commands =
+  flake8 --verbose
+
+[testenv:py38-tests]
+platform = linux
+deps =
+  pytest
+  pytest-cov
+commands=
+  pytest


### PR DESCRIPTION
This PR implements periodically scheduled CLI actions.
In the process it adds support for one-shot event registrations (i.e. registering for an event and having the callback happen only once).
