### PR TITLE
Fix an error where LB cleanup would falsely remove ELBs/ALBs if pricing API returns invalid results

### DIFF
--- a/cloudkeeper/cloudkeeper/baseresources.py
+++ b/cloudkeeper/cloudkeeper/baseresources.py
@@ -655,6 +655,7 @@ class BaseLoadBalancer(BaseResource):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.lb_type = ''
+        self.backends = []
 
     def metrics(self, graph) -> Dict:
         self._metrics['load_balancers_total'][(self.cloud(graph).name, self.account(graph).name, self.region(graph).name, self.lb_type)] = 1

--- a/plugins/aws/cloudkeeper_plugin_aws/accountcollector.py
+++ b/plugins/aws/cloudkeeper_plugin_aws/accountcollector.py
@@ -18,6 +18,7 @@ from prometheus_client import Summary, Counter
 from pkg_resources import resource_filename
 from typing import List, Optional, Dict, Tuple
 from retrying import retry
+from pprint import pformat
 
 
 log = logging.getLogger('cloudkeeper.' + __name__)
@@ -1373,6 +1374,9 @@ class AWSAccountCollector:
                         'tenancy': {}
                     }
                 price_info[instance_type]['tenancy'][ec2_tenancy] = price
+            if instance_type not in price_info:
+                log.error(f"Error in pricing API call, instance type {instance_type} was not found in price list: {pformat(price_list)}")
+                return None
             node = AWSEC2InstanceType(instance_type, {}, account=self.account, region=region)
             node.instance_cores = price_info[instance_type]['cores']
             node.instance_memory = price_info[instance_type]['memory']


### PR DESCRIPTION
Fixes an issue where if the Pricing API returned invalid data the collection of EC2 instances would abort leading to no instances being connected to ALBs/ELBs in the Graph. This would then cause the LB Cleanup Plugin to think that the LBs are orphaned and remove them.