### PR TITLE
Double check the number of backends in AWS LB cleanup

### DIFF
--- a/plugins/aws/cloudkeeper_plugin_aws/accountcollector.py
+++ b/plugins/aws/cloudkeeper_plugin_aws/accountcollector.py
@@ -910,7 +910,6 @@ class AWSAccountCollector:
                     log.debug(f'Adding edge from ALB Target Group {tg.id} to ALB {alb.id}')
                     graph.add_edge(tg, alb)
 
-
     @metrics_collect_albs.time()
     def collect_albs(self, region: AWSRegion, graph: Graph) -> None:
         log.info(f'Collecting AWS ALBs in account {self.account.id} region {region.id}')


### PR DESCRIPTION
This uses the new .backends loadbalancer attribute when performing cleanup to double check that a) there's no backends in the graph and b) there's no backends added to the LB node itself.