### PR TITLE
Config file support for Cleanup AWS VPCs plugin

### DIFF
--- a/plugins/aws/cloudkeeper_plugin_aws/resources.py
+++ b/plugins/aws/cloudkeeper_plugin_aws/resources.py
@@ -634,7 +634,7 @@ class AWSCloudFormationStack(AWSResource, BaseStack):
         start_utime = time.time()
         while stack.stack_status.endswith('_IN_PROGRESS'):
             if time.time() > start_utime + timeout:
-                raise TimeoutError(f'Stack {stack.name} tag update timed out after {timeout} seconds with status {stack.stack_status}')
+                raise TimeoutError(f'AWS Cloudformation Stack {self.dname} tag update timed out after {timeout} seconds with status {stack.stack_status}')
             time.sleep(5)
             stack = cloudformation_resource.Stack(stack.name)
         return stack

--- a/plugins/cleanup_aws_vpcs/README.md
+++ b/plugins/cleanup_aws_vpcs/README.md
@@ -22,6 +22,21 @@ Turn on general cleanup using the `--cleanup` argument and activate this plugin 
 $ cloudkeeper -v --cleanup --cleanup-aws-vpcs
 ```
 
+Instead of targeting all VPCs that have been marked for cleanup the plugin supports a config file syntax for whitelisting individual accounts.
+```
+$ cloudkeeper -v --cleanup --cleanup-aws-vpcs --cleanup-aws-vpcs-config cleanup_aws_vpcs.yaml
+```
+
+The config file is a dict with a cloud ID as key and a list of account IDs as value.
+```
+'aws':
+  - '337834004759'
+  - '999867407951'
+  - '327650738955'
+  - '068564737731'
+  - '711585860468'
+```
+
 ## List of arguments
 ```
 ```

--- a/plugins/cleanup_aws_vpcs/README.md
+++ b/plugins/cleanup_aws_vpcs/README.md
@@ -39,4 +39,7 @@ The config file is a dict with a cloud ID as key and a list of account IDs as va
 
 ## List of arguments
 ```
+  --cleanup-aws-vpcs    Cleanup AWS VPCs (default: False)
+  --cleanup-aws-vpcs-config CLEANUP_AWS_VPCS_CONFIG
+                        Path to Cleanup AWS VPCs Plugin Config
 ```

--- a/plugins/cleanup_aws_vpcs/setup.py
+++ b/plugins/cleanup_aws_vpcs/setup.py
@@ -23,6 +23,7 @@ setup(
     install_requires=[
         'cloudkeeper',
         'cloudkeeper-plugin-aws',
+        'pyyaml'
     ],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],

--- a/plugins/cleanup_aws_vpcs/test/test_args.py
+++ b/plugins/cleanup_aws_vpcs/test/test_args.py
@@ -7,3 +7,4 @@ def test_args():
     CleanupAWSVPCsPlugin.add_args(arg_parser)
     arg_parser.parse_args()
     assert ArgumentParser.args.cleanup_aws_vpcs is False
+    assert ArgumentParser.args.cleanup_aws_vpcs_config is None


### PR DESCRIPTION
Instead of targeting all VPCs marked for cleaning in all accounts, users can now whitelist account IDs in a config file.